### PR TITLE
Fix bug with getClasses/getParent/getStudents throwing RuntimeException when the parameter contains non-alphanumeric chararcters

### DIFF
--- a/src/main/java/seedu/address/logic/parser/GetClassesCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/GetClassesCommandParser.java
@@ -34,8 +34,12 @@ public class GetClassesCommandParser implements Parser<GetClassesCommand> {
             throw new ParseException(String.format(
                     MESSAGE_INVALID_COMMAND_FORMAT, GetClassesCommand.MESSAGE_USAGE));
         }
-
-        Name tutorName = new Name(rawName);
+        Name tutorName;
+        try {
+            tutorName = new Name(rawName);
+        } catch (IllegalArgumentException e) {
+            throw new ParseException(e.getMessage());
+        }
         return new GetClassesCommand(tutorName);
     }
 }

--- a/src/main/java/seedu/address/logic/parser/GetParentCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/GetParentCommandParser.java
@@ -34,7 +34,12 @@ public class GetParentCommandParser implements Parser<GetParentCommand> {
                     MESSAGE_INVALID_COMMAND_FORMAT, GetParentCommand.MESSAGE_USAGE));
         }
 
-        Name studentName = new Name(rawName);
+        Name studentName;
+        try {
+            studentName = new Name(rawName);
+        } catch (IllegalArgumentException e) {
+            throw new ParseException(e.getMessage());
+        }
         return new GetParentCommand(studentName);
     }
 }

--- a/src/main/java/seedu/address/logic/parser/GetStudentsCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/GetStudentsCommandParser.java
@@ -35,7 +35,12 @@ public class GetStudentsCommandParser implements Parser<GetStudentsCommand> {
                     MESSAGE_INVALID_COMMAND_FORMAT, GetStudentsCommand.MESSAGE_USAGE));
         }
 
-        Name tutorName = new Name(rawName);
+        Name tutorName;
+        try {
+            tutorName = new Name(rawName);
+        } catch (IllegalArgumentException e) {
+            throw new ParseException(e.getMessage());
+        }
         return new GetStudentsCommand(tutorName);
     }
 }


### PR DESCRIPTION
When getClasses/getParent/getStudents is run with non-alphanumeric characters in the n/NAME parameter, the app will not respond and the command box does not update (when it usually displays an error message of some kind to let the user know why the command didn't run).

With no feedback to the user on why the command fails to run, it makes it hard for users to fix the issue and continue to use the app smoothly.

Let's update the relevant parser classes to properly catch the IllegalArgumentException and convert it to a ParseException, so that the error logic of our code can handle it as expected.

Throughout our code, the ParseException is used to contain any errors with parsing, attaching the relevant error message to it, for it to be caught by the main logic and processed to be displayed in the GUI. The main logic, however, is not designed to catch IllegalArgumentExceptions, so it gets caught by the backend instead and does not update the GUI in any way.

The IllegalArgumentException is thrown by the attempt to create a new Name object in the parser classes. More specifically, the constructor method for Name calls AppUtils::checkArgument, which takes in a boolean (where the coder can input any conditional that evaluates to a boolean) and throws the IllegalArgumentException if false.

Closes #209 
Closes #210 
Closes #211 